### PR TITLE
Increase default `searchLimit`

### DIFF
--- a/template-doks/config/_default/hyas/doks.toml
+++ b/template-doks/config/_default/hyas/doks.toml
@@ -19,7 +19,7 @@ showSearch = [] # [] (all pages, default) or homepage (optionally) and list of s
 ## Search results
 showDate = false # false (default) or true
 showSummary = true # true (default) or false
-searchLimit = 5 # 0 (no limit, default) or natural number
+searchLimit = 99 # 0 (no limit, default) or natural number
 
 # Global alert
 alert = false # false (default) or true


### PR DESCRIPTION
Was there a specific reason for the low former limit of 5?